### PR TITLE
kernel: fix jffs2 compilation with GCC_PLUGIN_RANDSTRUCT enabled

### DIFF
--- a/target/linux/generic/pending-5.15/530-jffs2_make_lzma_available.patch
+++ b/target/linux/generic/pending-5.15/530-jffs2_make_lzma_available.patch
@@ -351,7 +351,7 @@ Signed-off-by: Alexandros C. Couloumbis <alex@ozo.com>
 +		LZMA_FREE(address);
 +}
 +
-+static ISzAlloc lzma_alloc = {p_lzma_malloc, p_lzma_free};
++static ISzAlloc lzma_alloc = { .Alloc = p_lzma_malloc, .Free = p_lzma_free };
 +
 +#endif
 --- /dev/null

--- a/target/linux/generic/pending-6.1/530-jffs2_make_lzma_available.patch
+++ b/target/linux/generic/pending-6.1/530-jffs2_make_lzma_available.patch
@@ -351,7 +351,7 @@ Signed-off-by: Alexandros C. Couloumbis <alex@ozo.com>
 +		LZMA_FREE(address);
 +}
 +
-+static ISzAlloc lzma_alloc = {p_lzma_malloc, p_lzma_free};
++static ISzAlloc lzma_alloc = { .Alloc = p_lzma_malloc, .Free = p_lzma_free };
 +
 +#endif
 --- /dev/null


### PR DESCRIPTION
Designated initializers are required when using the randstruct GCC plugin, otherwise an error like the following is seen:

./include/linux/lzma.h:60:31: error: positional initialization of field in 'struct' declared with 'designated_init' attribute [-Werror=designated-init]

This was originally applied via 55643e469c21, but was unintentionally reverted in 483503603cb2.

Fixes: 483503603cb2 ("generic: 5.15: rework pending patch")